### PR TITLE
shrinking release size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,8 @@
 [workspace]
 members = ["benchmark", "dprint_plugin", "malva", "malva_cli", "playground_wasm"]
 resolver = "2"
+
+[profile.release]
+lto = true
+opt-level = "s"
+strip = "debuginfo"


### PR DESCRIPTION
This setting will reduce the size of wasm to half its original size.
It may also be useful for native build.