### PR TITLE
Don't lowercase properties in unknown at-rulesets

### DIFF
--- a/malva/src/doc_gen/at_rule/mod.rs
+++ b/malva/src/doc_gen/at_rule/mod.rs
@@ -45,10 +45,13 @@ impl<'s> DocGen<'s> for AtRule<'s> {
                 block.span.start,
                 ctx,
             ));
-            docs.push(block.doc(ctx, &State {
-                in_unknown_at_rule,
-                ..state.clone()
-            }));
+            docs.push(block.doc(
+                ctx,
+                &State {
+                    in_unknown_at_rule,
+                    ..state.clone()
+                },
+            ));
         }
 
         Doc::list(docs)

--- a/malva/src/doc_gen/at_rule/mod.rs
+++ b/malva/src/doc_gen/at_rule/mod.rs
@@ -31,9 +31,9 @@ impl<'s> DocGen<'s> for AtRule<'s> {
         let mut in_unknown_at_rule = false;
 
         if let Some(prelude) = &self.prelude {
+            in_unknown_at_rule = matches!(prelude, AtRulePrelude::Unknown(_));
             docs.push(Doc::space());
             let span = prelude.span();
-            in_unknown_at_rule = matches!(prelude, AtRulePrelude::Unknown(_));
             docs.extend(ctx.end_spaced_comments(ctx.get_comments_between(pos, span.start)));
             docs.push(prelude.doc(ctx, state));
             pos = span.end;

--- a/malva/src/doc_gen/at_rule/mod.rs
+++ b/malva/src/doc_gen/at_rule/mod.rs
@@ -28,9 +28,12 @@ impl<'s> DocGen<'s> for AtRule<'s> {
             self.name.raw.to_ascii_lowercase()
         )));
 
+        let mut in_unknown_at_rule = false;
+
         if let Some(prelude) = &self.prelude {
             docs.push(Doc::space());
             let span = prelude.span();
+            in_unknown_at_rule = matches!(prelude, AtRulePrelude::Unknown(_));
             docs.extend(ctx.end_spaced_comments(ctx.get_comments_between(pos, span.start)));
             docs.push(prelude.doc(ctx, state));
             pos = span.end;
@@ -42,7 +45,10 @@ impl<'s> DocGen<'s> for AtRule<'s> {
                 block.span.start,
                 ctx,
             ));
-            docs.push(block.doc(ctx, state));
+            docs.push(block.doc(ctx, &State {
+                in_unknown_at_rule,
+                ..state.clone()
+            }));
         }
 
         Doc::list(docs)

--- a/malva/src/doc_gen/at_rule/mod.rs
+++ b/malva/src/doc_gen/at_rule/mod.rs
@@ -22,21 +22,20 @@ impl<'s> DocGen<'s> for AtRule<'s> {
     fn doc(&self, ctx: &Ctx<'_, 's>, state: &State) -> Doc<'s> {
         let mut docs = Vec::with_capacity(5);
         let mut pos = self.name.span.end;
+        let mut in_unknown_at_rule = false;
 
         docs.push(Doc::text(format!(
             "@{}",
             self.name.raw.to_ascii_lowercase()
         )));
 
-        let mut in_unknown_at_rule = false;
-
         if let Some(prelude) = &self.prelude {
-            in_unknown_at_rule = matches!(prelude, AtRulePrelude::Unknown(_));
             docs.push(Doc::space());
             let span = prelude.span();
             docs.extend(ctx.end_spaced_comments(ctx.get_comments_between(pos, span.start)));
             docs.push(prelude.doc(ctx, state));
             pos = span.end;
+            in_unknown_at_rule = matches!(prelude, AtRulePrelude::Unknown(_));
         }
 
         if let Some(block) = &self.block {

--- a/malva/src/doc_gen/helpers.rs
+++ b/malva/src/doc_gen/helpers.rs
@@ -314,7 +314,7 @@ pub(super) fn ident_to_lowercase<'s>(
     state: &State,
 ) -> Doc<'s> {
     match &interpolable_ident {
-        InterpolableIdent::Literal(ident) if !ident.name.starts_with("--") => {
+        InterpolableIdent::Literal(ident) if !ident.name.starts_with("--") && !state.in_unknown_at_rule => {
             Doc::text(ident.raw.to_ascii_lowercase())
         }
         name => name.doc(ctx, state),

--- a/malva/src/doc_gen/helpers.rs
+++ b/malva/src/doc_gen/helpers.rs
@@ -314,7 +314,9 @@ pub(super) fn ident_to_lowercase<'s>(
     state: &State,
 ) -> Doc<'s> {
     match &interpolable_ident {
-        InterpolableIdent::Literal(ident) if !ident.name.starts_with("--") && !state.in_unknown_at_rule => {
+        InterpolableIdent::Literal(ident)
+            if !ident.name.starts_with("--") && !state.in_unknown_at_rule =>
+        {
             Doc::text(ident.raw.to_ascii_lowercase())
         }
         name => name.doc(ctx, state),

--- a/malva/src/lib.rs
+++ b/malva/src/lib.rs
@@ -79,6 +79,7 @@ pub fn print_stylesheet<'a, 's>(
     };
     let state = State {
         in_less_detached_ruleset: false,
+        in_unknown_at_rule: false,
         selector_override: crate::state::SelectorOverride::Unset,
     };
     let doc = stylesheet.doc(&ctx, &state);

--- a/malva/src/state.rs
+++ b/malva/src/state.rs
@@ -1,6 +1,7 @@
 #[derive(Clone)]
 pub(crate) struct State {
     pub(crate) in_less_detached_ruleset: bool,
+    pub(crate) in_unknown_at_rule: bool,
     pub(crate) selector_override: SelectorOverride,
 }
 

--- a/malva/tests/fmt/css/case/case.css
+++ b/malva/tests/fmt/css/case/case.css
@@ -8,7 +8,7 @@ p:FIRST-CHILD {
     color: lime;
     background-color: black;
     padding: 5px;
-}@plug
+}
 
 a::AFTER {
     content: "→";

--- a/malva/tests/fmt/css/case/case.css
+++ b/malva/tests/fmt/css/case/case.css
@@ -8,7 +8,7 @@ p:FIRST-CHILD {
     color: lime;
     background-color: black;
     padding: 5px;
-}
+}@plug
 
 a::AFTER {
     content: "→";
@@ -59,4 +59,9 @@ x-panel {
 }
 :host(:hover) {
     transform: scale(1.1);
+}
+
+@plugin "daisyui/theme" {
+  name: "dark";
+  prefersDark: true;
 }

--- a/malva/tests/fmt/css/case/case.snap
+++ b/malva/tests/fmt/css/case/case.snap
@@ -63,3 +63,8 @@ x-panel {
 :host(:hover) {
   transform: scale(1.1);
 }
+
+@plugin "daisyui/theme" {
+  name: "dark";
+  prefersDark: true;
+}


### PR DESCRIPTION
Fixes https://github.com/g-plane/malva/issues/17

I'm not sure if this is a fully correct fix, but seems better to ignore casing in unknown
rulesets than to change them potentially rendering them broken.