### PR TITLE
fix: preserve Less negative values

### DIFF
--- a/malva/src/doc_gen/less.rs
+++ b/malva/src/doc_gen/less.rs
@@ -46,8 +46,6 @@ impl<'a, 's: 'a> DocGen<'a, 's> for LessBinaryConditionOperator {
 
 impl<'a, 's: 'a> DocGen<'a, 's> for LessBinaryOperation<'s> {
     fn doc(&self, ctx: &Ctx<'a, 's>, state: &State) -> Doc<'s> {
-        let is_spaced_unary_negative = is_spaced_unary_negative_operation(self);
-
         self.left
             .doc(ctx, state)
             .append(helpers::format_operator_prefix_space(ctx))
@@ -55,51 +53,12 @@ impl<'a, 's: 'a> DocGen<'a, 's> for LessBinaryOperation<'s> {
                 ctx.get_comments_between(self.left.span().end, self.op.span.start),
             ))
             .append(self.op.doc(ctx, state))
-            .append(if is_spaced_unary_negative {
-                Doc::nil()
-            } else {
-                helpers::format_operator_suffix_space(ctx)
-            })
+            .append(helpers::format_operator_suffix_space(ctx))
             .concat(ctx.end_spaced_comments(
                 ctx.get_comments_between(self.op.span.end, self.right.span().start),
             ))
             .append(self.right.doc(ctx, state))
             .group()
-    }
-}
-
-fn is_spaced_unary_negative_operation(operation: &LessBinaryOperation) -> bool {
-    // Less treats `a -@b` and `a -(@b)` as a value followed by a negative value.
-    matches!(operation.op.kind, LessOperationOperatorKind::Minus)
-        && operation.left.span().end < operation.op.span.start
-        && operation.op.span.end == operation.right.span().start
-        && starts_with_less_negative_value(&operation.right)
-}
-
-fn starts_with_less_negative_value(value: &ComponentValue) -> bool {
-    match value {
-        // The right side may be a higher-precedence expression such as
-        // `@b * 2`; Less negative-value syntax only depends on the first atom.
-        ComponentValue::LessBinaryOperation(operation) => {
-            starts_with_less_negative_value(&operation.left)
-        }
-        value => is_less_negative_value_atom(value),
-    }
-}
-
-fn is_less_negative_value_atom(value: &ComponentValue) -> bool {
-    match value {
-        ComponentValue::LessVariable(..)
-        | ComponentValue::LessVariableVariable(..)
-        | ComponentValue::LessPropertyVariable(..)
-        | ComponentValue::LessParenthesizedOperation(..) => true,
-        ComponentValue::LessNamespaceValue(namespace_value) => {
-            matches!(
-                &namespace_value.callee,
-                LessNamespaceValueCallee::LessVariable(..)
-            )
-        }
-        _ => false,
     }
 }
 

--- a/malva/src/doc_gen/less.rs
+++ b/malva/src/doc_gen/less.rs
@@ -73,10 +73,21 @@ fn is_spaced_unary_negative_operation(operation: &LessBinaryOperation) -> bool {
     matches!(operation.op.kind, LessOperationOperatorKind::Minus)
         && operation.left.span().end < operation.op.span.start
         && operation.op.span.end == operation.right.span().start
-        && can_be_less_negative_value(&operation.right)
+        && starts_with_less_negative_value(&operation.right)
 }
 
-fn can_be_less_negative_value(value: &ComponentValue) -> bool {
+fn starts_with_less_negative_value(value: &ComponentValue) -> bool {
+    match value {
+        // The right side may be a higher-precedence expression such as
+        // `@b * 2`; Less negative-value syntax only depends on the first atom.
+        ComponentValue::LessBinaryOperation(operation) => {
+            starts_with_less_negative_value(&operation.left)
+        }
+        value => is_less_negative_value_atom(value),
+    }
+}
+
+fn is_less_negative_value_atom(value: &ComponentValue) -> bool {
     match value {
         ComponentValue::LessVariable(..)
         | ComponentValue::LessVariableVariable(..)

--- a/malva/src/doc_gen/less.rs
+++ b/malva/src/doc_gen/less.rs
@@ -46,6 +46,8 @@ impl<'a, 's: 'a> DocGen<'a, 's> for LessBinaryConditionOperator {
 
 impl<'a, 's: 'a> DocGen<'a, 's> for LessBinaryOperation<'s> {
     fn doc(&self, ctx: &Ctx<'a, 's>, state: &State) -> Doc<'s> {
+        let is_spaced_unary_negative = is_spaced_unary_negative_operation(self);
+
         self.left
             .doc(ctx, state)
             .append(helpers::format_operator_prefix_space(ctx))
@@ -53,12 +55,40 @@ impl<'a, 's: 'a> DocGen<'a, 's> for LessBinaryOperation<'s> {
                 ctx.get_comments_between(self.left.span().end, self.op.span.start),
             ))
             .append(self.op.doc(ctx, state))
-            .append(helpers::format_operator_suffix_space(ctx))
+            .append(if is_spaced_unary_negative {
+                Doc::nil()
+            } else {
+                helpers::format_operator_suffix_space(ctx)
+            })
             .concat(ctx.end_spaced_comments(
                 ctx.get_comments_between(self.op.span.end, self.right.span().start),
             ))
             .append(self.right.doc(ctx, state))
             .group()
+    }
+}
+
+fn is_spaced_unary_negative_operation(operation: &LessBinaryOperation) -> bool {
+    // Less treats `a -@b` and `a -(@b)` as a value followed by a negative value.
+    matches!(operation.op.kind, LessOperationOperatorKind::Minus)
+        && operation.left.span().end < operation.op.span.start
+        && operation.op.span.end == operation.right.span().start
+        && can_be_less_negative_value(&operation.right)
+}
+
+fn can_be_less_negative_value(value: &ComponentValue) -> bool {
+    match value {
+        ComponentValue::LessVariable(..)
+        | ComponentValue::LessVariableVariable(..)
+        | ComponentValue::LessPropertyVariable(..)
+        | ComponentValue::LessParenthesizedOperation(..) => true,
+        ComponentValue::LessNamespaceValue(namespace_value) => {
+            matches!(
+                &namespace_value.callee,
+                LessNamespaceValueCallee::LessVariable(..)
+            )
+        }
+        _ => false,
     }
 }
 

--- a/malva/tests/fmt/less/negative-value/negative-value.less
+++ b/malva/tests/fmt/less/negative-value/negative-value.less
@@ -1,0 +1,25 @@
+@card-spacing: 15px;
+
+.cards {
+  margin: 0 -@card-spacing;
+}
+
+.variable {
+  margin: 2 -@card-spacing;
+}
+
+.variable-binary-spaced {
+  margin: 2 - @card-spacing;
+}
+
+.variable-binary-tight {
+  margin: 2-@card-spacing;
+}
+
+.parens {
+  margin: 2 -(@card-spacing);
+}
+
+.parens-binary-spaced {
+  margin: 2 - (@card-spacing);
+}

--- a/malva/tests/fmt/less/negative-value/negative-value.less
+++ b/malva/tests/fmt/less/negative-value/negative-value.less
@@ -23,3 +23,52 @@
 .parens-binary-spaced {
   margin: 2 - (@card-spacing);
 }
+
+@spacing-name: card-spacing;
+@spacing-map: {
+  card: 15px;
+};
+
+.times-keeps-unary-variable {
+  margin: 2 -@card-spacing * 2;
+}
+
+.division-keeps-unary-variable {
+  margin: 2 -@card-spacing / 2;
+}
+
+.addition-keeps-unary-variable {
+  margin: 2 -@card-spacing + 1px;
+}
+
+.indirect-variable-product {
+  margin: 2 -@@spacing-name * 2;
+}
+
+.namespace-lookup-product {
+  margin: 2 -@spacing-map[card] * 2;
+}
+
+.parenthesized-variable-product {
+  margin: 2 -(@card-spacing) * 2;
+}
+
+.parenthesized-expression-product {
+  margin: 2 -(@card-spacing + 1px) * 2;
+}
+
+.spaced-minus-product {
+  margin: 2 - @card-spacing * 2;
+}
+
+.spaced-minus-parenthesized-product {
+  margin: 2 - (@card-spacing) * 2;
+}
+
+.trailing-comment-product {
+  margin: 2 -@card-spacing /* comment */ * 2;
+}
+
+.comment-breaks-unary-minus {
+  margin: 2 -/* comment */@card-spacing * 2;
+}

--- a/malva/tests/fmt/less/negative-value/negative-value.snap
+++ b/malva/tests/fmt/less/negative-value/negative-value.snap
@@ -26,3 +26,52 @@ source: malva/tests/fmt.rs
 .parens-binary-spaced {
   margin: 2 - (@card-spacing);
 }
+
+@spacing-name: card-spacing;
+@spacing-map: {
+  card: 15px;
+};
+
+.times-keeps-unary-variable {
+  margin: 2 -@card-spacing * 2;
+}
+
+.division-keeps-unary-variable {
+  margin: 2 -@card-spacing / 2;
+}
+
+.addition-keeps-unary-variable {
+  margin: 2 -@card-spacing + 1px;
+}
+
+.indirect-variable-product {
+  margin: 2 -@@spacing-name * 2;
+}
+
+.namespace-lookup-product {
+  margin: 2 -@spacing-map[card] * 2;
+}
+
+.parenthesized-variable-product {
+  margin: 2 -(@card-spacing) * 2;
+}
+
+.parenthesized-expression-product {
+  margin: 2 -(@card-spacing + 1px) * 2;
+}
+
+.spaced-minus-product {
+  margin: 2 - @card-spacing * 2;
+}
+
+.spaced-minus-parenthesized-product {
+  margin: 2 - (@card-spacing) * 2;
+}
+
+.trailing-comment-product {
+  margin: 2 -@card-spacing /* comment */ * 2;
+}
+
+.comment-breaks-unary-minus {
+  margin: 2 - /* comment */ @card-spacing * 2;
+}

--- a/malva/tests/fmt/less/negative-value/negative-value.snap
+++ b/malva/tests/fmt/less/negative-value/negative-value.snap
@@ -1,0 +1,28 @@
+---
+source: malva/tests/fmt.rs
+---
+@card-spacing: 15px;
+
+.cards {
+  margin: 0 -@card-spacing;
+}
+
+.variable {
+  margin: 2 -@card-spacing;
+}
+
+.variable-binary-spaced {
+  margin: 2 - @card-spacing;
+}
+
+.variable-binary-tight {
+  margin: 2 - @card-spacing;
+}
+
+.parens {
+  margin: 2 -(@card-spacing);
+}
+
+.parens-binary-spaced {
+  margin: 2 - (@card-spacing);
+}


### PR DESCRIPTION
<!--
AI-assisted development is allowed. However, contributors are expected to understand and review everything they submit. Pull request descriptions must be written manually by the author and must accurately explain the purpose and rationale of the changes. Low-quality or blindly AI-generated submissions may be closed without review.
-->

- [ ] The pull request description was written manually by me and was not generated by an AI tool or agent.
- [x] I have read and understood the relevant parts of the existing codebase before making these changes.
- [x] I have carefully reviewed and understood all code changes, and ensured that they match the style, architecture, and conventions of the existing codebase.
- [x] I understand that pull requests containing blindly generated or unreviewed AI-generated code may be closed without review.


## Summary

Fixes Less formatting for negative values that appear after another value.

Malva previously formatted:

```less
margin: 0 -@card-spacing;
```

as:

```less
margin: 0 - @card-spacing;
```

In Less, those are not equivalent. The first is a value list containing `0` and `-@card-spacing`; the second is binary subtraction.

This PR preserves unary negative values such as:

```less
margin: 0 -@card-spacing;
margin: 0 -(@card-spacing);
```

while still formatting actual binary subtraction normally:

```less
margin: 0 - @card-spacing;
margin: 0 - (@card-spacing);
```

## Format Flow

```mermaid
flowchart TD
  A["Less input: margin: 2 -@x * 2"] --> B["Raffia AST: LessBinaryOperation"]
  B --> C{"Is spaced unary negative?"}

  C -->|"minus operator, left ends before -, and - touches right"| D["Find the start atom of the right expression"]
  C -->|"otherwise"| E["Print operator with normal spacing"]

  D --> F["If right is nested LessBinaryOperation, follow its left operand"]
  F --> G{"Start atom can be a Less negative value?"}

  G -->|"yes: @var, @@var, $prop, (...), or @var[lookup]"| H["Print operator without suffix space"]
  G -->|"no"| E

  H --> I["Output: margin: 2 -@x * 2"]
  E --> J["Output: binary subtraction formatting"]
  I --> K["Less value-list semantics preserved"]
```

## Tests

Added Less snapshot coverage for:

- `margin: 2 -@card-spacing;`
- `margin: 2 - @card-spacing;`
- `margin: 2-@card-spacing;`
- `margin: 2 -(@card-spacing);`
- `margin: 2 - (@card-spacing);`

Also updated the existing parenthesized negative-value snapshot to preserve Less semantics.

Verified with:

```bash
cargo fmt --all --check
RUST_MIN_STACK=33554432 cargo test
```

- Fixes #61.
